### PR TITLE
Add notes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
-# README
+# Enhance SSR Ruby on Rails Example
+This project demonstrates using Enhance to serverside render components in Rails.
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## Install Extism Runtime Dependency
+For this library, you first need to install the Extism Runtime by following the instructions in the [Ruby SDK Repository](https://github.com/extism/ruby-sdk#install-the-extism-runtime-dependency).
 
-Things you may want to cover:
+```sh
+curl https://get.extism.org/cli | sh
+sudo extism lib install latest
+```
 
-* Ruby version
+## Download Enhance SSR wasm
+The compiled WASM already exists in `lib/enhance-ssr.wasm`, but you can also download the latest release of the compiled wasm:
+```sh
+curl -L https://github.com/enhance-dev/enhance-ssr-wasm/releases/download/v0.0.3/enhance-ssr.wasm.gz | gunzip > lib/enhance-ssr.wasm
+```
 
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## Run
+1. Install Dependencies
+```sh
+bundle install
+```
+2. Run Server
+```sh
+bin/rails server
+```
+3. load http://localhost:3000


### PR DESCRIPTION
Readme largely copied and modified from Sinatra repo

Other possible improvements:

- Move `lib/enhance-ssr.wasm` into `vendor/enhance-ssr.wasm`, "vendor" is usually reserved for things like precompiled gems, binaries, etc. Whereas `lib/` is usually intended for Ruby code outside of main app.


Move content into and `app/views/home/index.html.erb` and then call `render_to_string`

```diff
-    markup = "<my-header>Hello World</my-header>"
+   markup =  render_to_string
```

^ This kind of takes away from the example, so maybe a separate example? idk.

The other thing is the current calls never call the layout, I haven't found a way to hook into Rails rendering yet to get the full string before you send it to the client, but you could also just manually pass the layout.

```diff
  def index
    path = Rails.root.join('lib', 'enhance-ssr.wasm')
    manifest = Extism::Manifest.from_path path
    plugin = Extism::Plugin.new(manifest, wasi:true)

    element_path = Rails.root.join('app', 'views', 'elements')
    elements = read_elements(element_path)
    markup = "<my-header>Hello World</my-header>"
    initial_state = {}
    data = { "markup" => markup, "elements" => elements, "initialState" => initial_state }
    payload = JSON.pretty_generate(data)
-  html_document = JSON.parse(plugin.call("ssr", payload))["document"]
-  render html: html_document.html_safe
+    body = JSON.parse(plugin.call("ssr", payload))["body"]
+    styles = "<style>#{JSON.parse(plugin.call("ssr", payload))["styles"]}</style>"
+    render html: (styles + "\n" + body).html_safe, layout: "application"
  end
```

^ Another minor thing, but makes sure youre not injecting a full HTML document or getting into quirks mode and can use app-level javascript in `application.html.erb`

I don't expect this stuff to get implemented as this is an example and may take away from showing how things work.